### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dependency Status][daviddm-image]][daviddm-url]
 [![Code Climate][codeclimate-image]][codeclimate-url]
 
-[swagger.io](http://swagger.io/) (v2.0) hook for [Sails](http://sailsjs.org). The application's models, controllers, and routes are aggregated and transformed in to a Swagger Document. Supports the Swagger 2.0 specification.
+[swagger.io](http://swagger.io/) (v2.0) hook for [Sails](http://sailsjs.org). The application's models, controllers, and routes are aggregated and transformed into a Swagger Document. Supports the Swagger 2.0 specification.
 
 ## Install
 


### PR DESCRIPTION
Found two typos, so fixed them. "In to" => "Into", and " Swagger integratoin for sails.js" => "Swagger integration for sails.js"
