### PR TITLE
Fix swagger paths generation to show DELETE doc

### DIFF
--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -98,10 +98,16 @@ const Transformer = {
       .reject({ path: '/csrfToken' })
       .reject({ path: '/csrftoken' })
       .groupBy('path')
-      .mapKeys((_, path) => {
-        return path.replace(/:(\w+)\??/g, '{$1}')
-      })
       .value()
+
+    pathGroups = _.reduce(pathGroups, function(result, routes, path) {
+      path = path.replace(/:(\w+)\??/g, '{$1}')
+      if (result[path])
+        result[path] = _.union(result[path], routes)
+      else
+        result[path] = routes
+      return result
+    }, [])
 
     return _.mapValues(pathGroups, (pathGroup, key) => {
       return Transformer.getPathItem(sails, pathGroup, key)


### PR DESCRIPTION
Fix a little bug that could hide some swagger paths.

For example, the retrieved REST blueprints routes looked like this

```
{ '/todo/:id?': 
    [ Route {
        path: '/todo/:id?',
        method: 'delete',
        callbacks: [Object],
        keys: [Object],
        regexp: /^\/todo(?:\/([^\/]+?))?\/?$/i } ],
  '/todo/:id': 
    [ Route {
        path: '/todo/:id',
        method: 'get',
        callbacks: [Object],
        keys: [Object],
        regexp: /^\/todo\/(?:([^\/]+?))\/?$/i },
      Route {
        path: '/todo/:id',
        method: 'post',
        callbacks: [Object],
        keys: [Object],
        regexp: /^\/todo\/(?:([^\/]+?))\/?$/i },
      Route {
        path: '/todo/:id',
        method: 'put',
        callbacks: [Object],
        keys: [Object],
        regexp: /^\/todo\/(?:([^\/]+?))\/?$/i } ] } 
```

Using the following code, the first entry was overridden and the `delete` path did not appear in the swagger document.

```
mapKeys((_, path) => {
    return path.replace(/:(\w+)\??/g, '{$1}')
})
```

I replaced it by `_.reduce()` to merge the paths of `'/todo/:id?'` and `'/todo/:id'`.

To illustrate the current behavior, on http://swagger.balderdash.io/, the request `DELETE /user/{id}` is not documented.

I would have added some unit tests, but the current tests do not check the structure of the document so deeply yet. It should probably be done when improving the tests of the whole generated swagger document. Maybe I could work on it...
