### PR TITLE
Associate correct tags when using blueprints prefixes

### DIFF
--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -12,6 +12,30 @@ const methodMap = {
   head: 'Get Resource headers'
 }
 
+function getBlueprintPrefixes() {
+  // Add a "/" to a prefix if it's missing
+  function formatPrefix(prefix) {
+    return (prefix.indexOf('/') !== 0 ? '/' : '') + prefix
+  }
+
+  let prefixes = []
+  // Check if blueprints hook is not removed
+  if (sails.config.blueprints) {
+    if (sails.config.blueprints.prefix) {
+      // Case of blueprints prefix
+      prefixes.push(formatPrefix(sails.config.blueprints.prefix))
+      if (sails.config.blueprints.rest && sails.config.blueprints.restPrefix) {
+        // Case of blueprints prefix + rest prefix
+        prefixes.unshift(prefixes[0] + formatPrefix(sails.config.blueprints.restPrefix))
+      }
+    } else if (sails.config.blueprints.rest && sails.config.blueprints.restPrefix) {
+      // Case of rest prefix
+      prefixes.push(formatPrefix(sails.config.blueprints.restPrefix))
+    }
+  }
+  return prefixes
+}
+
 const Transformer = {
 
   getSwagger (sails, pkg) {
@@ -177,38 +201,15 @@ const Transformer = {
   },
 
   getPathControllerTag (sails, methodGroup) {
-    // Add a "/" to a prefix if it's missing
-    function formatPrefix(prefix) {
-      return (prefix.indexOf('/') !== 0 ? '/' : '') + prefix
-    }
-
-    // Check if a path contains a prefix, remove it and search for a controller tag
-    function getPrefixedPathControllerTag(sails, path, prefix) {
-      prefix = formatPrefix(prefix)
-      if (path.indexOf(prefix) === 0) {
-        let [ $, pathToken ] = path.replace(prefix, '').split('/')
+    // Fist check if we can find a controller tag using prefixed blueprint routes
+    for (var prefix of getBlueprintPrefixes()) {
+      if (methodGroup.path.indexOf(prefix) === 0) {
+        let [ $, pathToken ] = methodGroup.path.replace(prefix, '').split('/')
         let tag = _.get(sails.controllers, [ pathToken, 'globalId' ])
-        return tag
-      }
-    }
-
-    if (sails.config.blueprints.prefix) {
-      if (sails.config.blueprints.rest && sails.config.blueprints.restPrefix) {
-        // Search a controller tag if the path contains a blueprint prefix and a blueprint restPrefix
-        let prefix = sails.config.blueprints.prefix + formatPrefix(sails.config.blueprints.restPrefix)
-        let tag = getPrefixedPathControllerTag(sails, methodGroup.path, prefix)
         if (tag) return tag
       }
-      // Search a controller tag if the path contains a blueprint prefix
-      let tag = getPrefixedPathControllerTag(sails, methodGroup.path, sails.config.blueprints.prefix)
-      if (tag) return tag
-    } else if (sails.config.blueprints.rest && sails.config.blueprints.restPrefix) {
-      // Search a controller tag if the path contains a blueprint restPrefix
-      let tag = getPrefixedPathControllerTag(sails, methodGroup.path, sails.config.blueprints.restPrefix)
-      if (tag) return tag
     }
 
-    // If we didn't find a tag
     let [ $, pathToken ] = methodGroup.path.split('/')
     return _.get(sails.controllers, [ pathToken, 'globalId' ])
   },

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -177,6 +177,38 @@ const Transformer = {
   },
 
   getPathControllerTag (sails, methodGroup) {
+    // Add a "/" to a prefix if it's missing
+    function formatPrefix(prefix) {
+      return (prefix.indexOf('/') !== 0 ? '/' : '') + prefix
+    }
+
+    // Check if a path contains a prefix, remove it and search for a controller tag
+    function getPrefixedPathControllerTag(sails, path, prefix) {
+      prefix = formatPrefix(prefix)
+      if (path.indexOf(prefix) === 0) {
+        let [ $, pathToken ] = path.replace(prefix, '').split('/')
+        let tag = _.get(sails.controllers, [ pathToken, 'globalId' ])
+        return tag
+      }
+    }
+
+    if (sails.config.blueprints.prefix) {
+      if (sails.config.blueprints.rest && sails.config.blueprints.restPrefix) {
+        // Search a controller tag if the path contains a blueprint prefix and a blueprint restPrefix
+        let prefix = sails.config.blueprints.prefix + formatPrefix(sails.config.blueprints.restPrefix)
+        let tag = getPrefixedPathControllerTag(sails, methodGroup.path, prefix)
+        if (tag) return tag
+      }
+      // Search a controller tag if the path contains a blueprint prefix
+      let tag = getPrefixedPathControllerTag(sails, methodGroup.path, sails.config.blueprints.prefix)
+      if (tag) return tag
+    } else if (sails.config.blueprints.rest && sails.config.blueprints.restPrefix) {
+      // Search a controller tag if the path contains a blueprint restPrefix
+      let tag = getPrefixedPathControllerTag(sails, methodGroup.path, sails.config.blueprints.restPrefix)
+      if (tag) return tag
+    }
+
+    // If we didn't find a tag
     let [ $, pathToken ] = methodGroup.path.split('/')
     return _.get(sails.controllers, [ pathToken, 'globalId' ])
   },


### PR DESCRIPTION
When configuring `sails.config.blueprints.prefix` and/or `sails.config.blueprints.restPrefix`, the controller tag was not correctly retrieved. Subsequently, the paths appeared in the "default" section of swagger-ui instead of a section having the API name.

This PL returns the corresponding tag when the first of these conditions is fulfilled:
- `blueprints.prefix` and `blueprints.restPrefix` match the route and a controller tag is found
- `blueprints.prefix` match the route and a controller tag is found
- `blueprints.restPrefix` match the route and a controller tag is found
- a controller tag is found

Whatever the configuration of `sails.config.blueprints.prefix` and `sails.config.blueprints.restPrefix` is, the path with be associated with a correct tag.
