### PR TITLE
Add support for pluralized routes, body parameters, and nested schemas

### DIFF
--- a/api/controllers/ContactController.js
+++ b/api/controllers/ContactController.js
@@ -1,0 +1,1 @@
+export default {}

--- a/api/controllers/GroupController.js
+++ b/api/controllers/GroupController.js
@@ -1,0 +1,1 @@
+export default {}

--- a/dist/api/controllers/ContactController.js
+++ b/dist/api/controllers/ContactController.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = {};
+module.exports = exports["default"];

--- a/dist/api/controllers/GroupController.js
+++ b/dist/api/controllers/GroupController.js
@@ -1,0 +1,7 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = {};
+module.exports = exports["default"];

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -83,9 +83,10 @@ const Transformer = {
    * http://swagger.io/specification/#definitionsObject
    */
   getDefinitions (sails) {
+
     let definitions = _.transform(sails.models, (definitions, model, modelName) => {
       definitions[model.identity] = {
-        properties: Transformer.getDefinitionProperties(model.definition)
+       properties: Transformer.getDefinitionProperties(model.definition)
       }
     })
 
@@ -95,12 +96,15 @@ const Transformer = {
   },
 
   getDefinitionProperties (definition) {
+
     return _.mapValues(definition, (def, attrName) => {
       let property = _.pick(def, [
-        'type', 'description', 'format'
+        'type', 'description', 'format', 'model'
       ])
 
-      return Spec.getPropertyType(property.type)
+      return property.model && sails.config.blueprints.populate
+          ? { '$ref': Transformer.generateDefinitionReference(property.model)}
+          : Spec.getPropertyType(property.type)
     })
   },
 
@@ -159,11 +163,15 @@ const Transformer = {
   /**
    * http://swagger.io/specification/#definitionsObject
    */
-  getDefinitionReference (sails, path) {
+  getDefinitionReferenceFromPath (sails, path) {
     let model = Transformer.getModelFromPath(sails, path)
     if (model) {
-      return '#/definitions/' + model.identity
+      return Transformer.generateDefinitionReference(model.identity)
     }
+  },
+
+  generateDefinitionReference (modelIdentity) {
+    return '#/definitions/' + modelIdentity
   },
 
   /**
@@ -271,7 +279,7 @@ const Transformer = {
           in: 'body',
           required: true,
           schema: {
-            $ref: Transformer.getDefinitionReference(sails, path)
+            $ref: Transformer.getDefinitionReferenceFromPath(sails, path)
           }
         })
       }
@@ -284,7 +292,7 @@ const Transformer = {
    * http://swagger.io/specification/#responsesObject
    */
   getResponses (sails, methodGroup) {
-    let $ref = Transformer.getDefinitionReference(sails, methodGroup.path)
+    let $ref = Transformer.getDefinitionReferenceFromPath(sails, methodGroup.path)
     let ok = {
       description: 'The requested resource'
     }

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -134,8 +134,8 @@ const Transformer = {
       return result
     }, [])
 
-    return _.mapValues(pathGroups, (pathGroup, key) => {
-      return Transformer.getPathItem(sails, pathGroup, key)
+    return _.mapValues(pathGroups, pathGroup => {
+      return Transformer.getPathItem(sails, pathGroup)
     })
   },
 
@@ -169,7 +169,7 @@ const Transformer = {
   /**
    * http://swagger.io/specification/#pathItemObject
    */
-  getPathItem (sails, pathGroup, pathkey) {
+  getPathItem (sails, pathGroup) {
     let methodGroups = _.chain(pathGroup)
       .indexBy('method')
       .pick([

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -83,7 +83,6 @@ const Transformer = {
    * http://swagger.io/specification/#definitionsObject
    */
   getDefinitions (sails) {
-
     let definitions = _.transform(sails.models, (definitions, model, modelName) => {
       definitions[model.identity] = {
         properties: Transformer.getDefinitionProperties(model.definition)

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -263,14 +263,18 @@ const Transformer = {
 
     if (canHavePayload) {
       let path = methodGroup.path
-      parameters.push({
-        name: Transformer.getModelIdentityFromPath(sails, path),
-        in: 'body',
-        required: true,
-        schema: {
-          $ref: Transformer.getDefinitionReference(sails, path)
-        }
-      })
+      let modelIdentity = Transformer.getModelIdentityFromPath(sails, path)
+
+      if (modelIdentity) {
+        parameters.push({
+          name: modelIdentity,
+          in: 'body',
+          required: true,
+          schema: {
+            $ref: Transformer.getDefinitionReference(sails, path)
+          }
+        })
+      }
     }
 
     return parameters

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -149,6 +149,13 @@ const Transformer = {
     return childModel || parentModel
   },
 
+  getModelIdentityFromPath (sails, path) {
+    let model = Transformer.getModelFromPath(sails, path)
+    if (model) {
+      return model.identity
+    }
+  },
+
   /**
    * http://swagger.io/specification/#definitionsObject
    */
@@ -238,11 +245,14 @@ const Transformer = {
    * http://swagger.io/specification/#parameterObject
    */
   getParameters (sails, methodGroup) {
-    let routeParams = methodGroup.keys
+    let method = methodGroup.method
+    let routeKeys= methodGroup.keys
 
-    if (!routeParams.length) return []
+    let canHavePayload = method === 'post' || method === 'put'
 
-    return _.map(routeParams, param => {
+    if (!routeKeys.length && !canHavePayload) return []
+
+    let parameters = _.map(routeKeys, param => {
       return {
         name: param.name,
         in: 'path',
@@ -250,6 +260,20 @@ const Transformer = {
         type: 'string'
       }
     })
+
+    if (canHavePayload) {
+      let path = methodGroup.path
+      parameters.push({
+        name: Transformer.getModelIdentityFromPath(sails, path),
+        in: 'body',
+        required: true,
+        schema: {
+          $ref: Transformer.getDefinitionReference(sails, path)
+        }
+      })
+    }
+
+    return parameters
   },
 
   /**

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -1,6 +1,7 @@
 import hoek from 'hoek'
 import _ from 'lodash'
 import Spec from './spec'
+import pluralize from 'pluralize'
 
 const methodMap = {
   post: 'Create Object(s)',
@@ -139,12 +140,11 @@ const Transformer = {
   },
 
   getModelFromPath (sails, path) {
-    let split = path.split('/')
     let [ $, parentModelName, parentId, childAttributeName, childId ] = path.split('/')
-    let parentModel = sails.models[parentModelName]
+    let parentModel = sails.models[parentModelName] || parentModelName ? sails.models[pluralize.singular(parentModelName)] : undefined
     let childAttribute = _.get(parentModel, [ 'attributes', childAttributeName ])
     let childModelName = _.get(childAttribute, 'collection') || _.get(childAttribute, 'model')
-    let childModel = sails.models[childModelName]
+    let childModel = sails.models[childModelName] || childModelName ? sails.models[pluralize.singular(childModelName)] : undefined
 
     return childModel || parentModel
   },

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -86,7 +86,7 @@ const Transformer = {
 
     let definitions = _.transform(sails.models, (definitions, model, modelName) => {
       definitions[model.identity] = {
-       properties: Transformer.getDefinitionProperties(model.definition)
+        properties: Transformer.getDefinitionProperties(model.definition)
       }
     })
 

--- a/lib/xfmr.js
+++ b/lib/xfmr.js
@@ -240,7 +240,7 @@ const Transformer = {
   getParameters (sails, methodGroup) {
     let routeParams = methodGroup.keys
 
-    if (!routeParams.length) return
+    if (!routeParams.length) return []
 
     return _.map(routeParams, param => {
       return {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "hoek": "^2.14.0",
     "lodash": "^3.10.1",
-    "marlinspike": "^0.12.10"
+    "marlinspike": "^0.12.10",
+    "pluralize": "^1.2.1"
   },
   "sails": {
     "isHook": true,

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -78,10 +78,10 @@ describe('xfmr', () => {
   })
   describe('#getDefinitionReference()', () => {
     it('should generate a Swagger $ref from a simple path /contact', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contacts'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact'))
     })
     it('should generate a Swagger $ref from a simple path /contact/:id', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contacts/:id'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact/:id'))
     })
     it('should generate a Swagger $ref from an association path /contact/:parentid/groups', () => {
       assert.equal('#/definitions/group', xfmr.getDefinitionReference(sails, '/contact/:parentid/group'))

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -78,16 +78,24 @@ describe('xfmr', () => {
   })
   describe('#getDefinitionReference()', () => {
     it('should generate a Swagger $ref from a simple path /contact', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contacts'))
     })
     it('should generate a Swagger $ref from a simple path /contact/:id', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact/:id'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contacts/:id'))
     })
     it('should generate a Swagger $ref from an association path /contact/:parentid/groups', () => {
       assert.equal('#/definitions/group', xfmr.getDefinitionReference(sails, '/contact/:parentid/group'))
     })
     it('should generate a Swagger $ref from an association path /group/:parentid/contacts/:id', () => {
       assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/group/:parentid/contacts/:id'))
+    })
+    it('should generate a Swagger $ref from a pluralized association path /users', () => {
+      sails.models['user'] = { identity: 'user' }
+      assert.equal('#/definitions/user', xfmr.getDefinitionReference(sails, '/users'))
+    })
+    it('should generate a Swagger $ref from a pluralized association path /memories', () => {
+      sails.models['memory'] = { identity: 'memory' }
+      assert.equal('#/definitions/memory', xfmr.getDefinitionReference(sails, '/memories'))
     })
   })
 })

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -8,7 +8,6 @@ describe('xfmr', () => {
     it('should generate complete and correct Swagger doc', () => {
       let swagger = xfmr.getSwagger(sails, pkg)
 
-
       assert(swagger)
     })
   })
@@ -51,19 +50,18 @@ describe('xfmr', () => {
       assert(_.isObject(swaggerOperation))
     })
   })
-  describe.skip('#getParameters', () => {
+  describe('#getParameters', () => {
     it('should generate an empty array for a Sails route with no keys', () => {
       let route = sails.router._privateRouter.routes.get[0]
-      let params = xfmr.getParameters(route)
+      let params = xfmr.getParameters(sails, route)
 
       assert(_.isArray(params))
       assert(_.isEmpty(params))
     })
     it('should generate a Swagger Parameters object from a Sails route', () => {
       let route = _.findWhere(sails.router._privateRouter.routes.get, { path: '/contact/:id' })
-      assert(route)
+      let params = xfmr.getParameters(sails, route)
 
-      let params = xfmr.getParameters(route)
       assert(_.isArray(params))
       assert.equal(params[0].name, 'id')
     })

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -74,13 +74,20 @@ describe('xfmr', () => {
       assert.equal(params[0].name, 'contact');
     })
     it('should generate a Swagger Parameters object from a Sails model for PUT endpoints', () => {
-      let route = _.findWhere(sails.router._privateRouter.routes.post, { path: '/contact/:id' })
+      let route = _.findWhere(sails.router._privateRouter.routes.put, { path: '/contact/:id' })
       let params = xfmr.getParameters(sails, route)
 
       assert(_.isArray(params))
       assert.equal(params.length, 2)
       assert.equal(params[0].name, 'id')
       assert.equal(params[1].name, 'contact');
+    })
+    it('should not generate a Swagger Parameters object when there is not a Sails model', () => {
+      let route = _.findWhere(sails.router._privateRouter.routes.post, { path: '/swagger/doc' })
+      let params = xfmr.getParameters(sails, route)
+
+      assert(_.isArray(params))
+      assert(_.isEmpty(params))
     })
   })
   describe.skip('#getResponses', () => {

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -119,7 +119,7 @@ describe('xfmr', () => {
   describe('#getResponses', () => {
     it('should generate a Swagger Responses object from a Sails route', () => {
       let route = sails.router._privateRouter.routes.get[0]
-      let swaggerResponses = xfmr.getResponses(route)
+      let swaggerResponses = xfmr.getResponses(sails, route)
 
       assert(_.isObject(swaggerResponses))
     })

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -11,6 +11,7 @@ describe('xfmr', () => {
       assert(swagger)
     })
   })
+
   describe('#getInfo', () => {
     it('should correctly transform package.json', () => {
       let info = xfmr.getInfo(pkg)
@@ -21,6 +22,7 @@ describe('xfmr', () => {
       assert(_.isString(info.version))
     })
   })
+
   describe('#getPaths', () => {
     it('should be able to access Sails routes', () => {
       assert(_.isObject(sails.router._privateRouter.routes))
@@ -32,24 +34,47 @@ describe('xfmr', () => {
     })
   })
 
-  describe.skip('#getPathItem', () => {
+  describe('#getPathItem', () => {
     it('should generate a Swagger Path Item object from a Sails route', () => {
-      let route = sails.router._privateRouter.routes.get[0]
-      let pathItem = xfmr.getPathItem(route)
+      let pathGroup = [
+        {
+          "path": "/group",
+          "method": "get",
+          "callbacks": [
+            null
+          ],
+          "keys": [],
+          "regexp": {}
+        },
+        {
+          "path": "/group",
+          "method": "post",
+          "callbacks": [
+            null
+          ],
+          "keys": [],
+          "regexp": {}
+        }
+      ]
+
+      let pathItem = xfmr.getPathItem(sails, pathGroup)
 
       assert(_.isObject(pathItem))
       assert(_.isObject(pathItem.get))
+      assert(_.isObject(pathItem.post))
+      assert(_.isUndefined(pathItem.put))
     })
   })
 
-  describe.skip('#getOperation', () => {
+  describe('#getOperation', () => {
     it('should generate a Swagger Operation object from a Sails route', () => {
       let route = sails.router._privateRouter.routes.get[0]
-      let swaggerOperation = xfmr.getOperation(route)
+      let swaggerOperation = xfmr.getOperation(sails, route, 'get')
 
       assert(_.isObject(swaggerOperation))
     })
   })
+
   describe('#getParameters', () => {
     it('should generate an empty array for a Sails route with no keys', () => {
       let route = sails.router._privateRouter.routes.get[0]
@@ -90,7 +115,8 @@ describe('xfmr', () => {
       assert(_.isEmpty(params))
     })
   })
-  describe.skip('#getResponses', () => {
+
+  describe('#getResponses', () => {
     it('should generate a Swagger Responses object from a Sails route', () => {
       let route = sails.router._privateRouter.routes.get[0]
       let swaggerResponses = xfmr.getResponses(route)
@@ -98,6 +124,7 @@ describe('xfmr', () => {
       assert(_.isObject(swaggerResponses))
     })
   })
+
   describe('#getDefinitionReference()', () => {
     it('should generate a Swagger $ref from a simple path /contact', () => {
       assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact'))

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -131,26 +131,57 @@ describe('xfmr', () => {
     })
   })
 
-  describe('#getDefinitionReference()', () => {
+  describe('#getDefinitions()', () => {
+    it('should generate a Swagger Definitions object', () => {
+      let swaggerDefinitions = xfmr.getDefinitions(sails);
+
+      assert(_.isObject(swaggerDefinitions))
+      assert(_.isObject(swaggerDefinitions.contact))
+      assert(_.isObject(swaggerDefinitions.group))
+    })
+    it('should generate a Swagger Definitions object with nested schemas', () => {
+      let swaggerDefinitions = xfmr.getDefinitions(sails);
+
+      assert(_.isObject(swaggerDefinitions.contact))
+      assert.deepEqual({ '$ref': '#/definitions/group' }, swaggerDefinitions.contact.properties.group)
+    })
+
+    context('populate turned off', () => {
+      before(() => {
+        sails.config.blueprints.populate = false
+      })
+      it('should generate a Swagger Definitions object with nested schemas', () => {
+        let swaggerDefinitions = xfmr.getDefinitions(sails);
+
+        assert(_.isObject(swaggerDefinitions.contact))
+        assert.deepEqual({ type: 'integer', format: 'int32' } , swaggerDefinitions.contact.properties.group)
+      })
+      after(() => {
+        sails.config.blueprints.populate = true
+      })
+    })
+  })
+
+  describe('#getDefinitionReferenceFromPath()', () => {
     it('should generate a Swagger $ref from a simple path /contact', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReferenceFromPath(sails, '/contact'))
     })
     it('should generate a Swagger $ref from a simple path /contact/:id', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/contact/:id'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReferenceFromPath(sails, '/contact/:id'))
     })
     it('should generate a Swagger $ref from an association path /contact/:parentid/groups', () => {
-      assert.equal('#/definitions/group', xfmr.getDefinitionReference(sails, '/contact/:parentid/group'))
+      assert.equal('#/definitions/group', xfmr.getDefinitionReferenceFromPath(sails, '/contact/:parentid/group'))
     })
     it('should generate a Swagger $ref from an association path /group/:parentid/contacts/:id', () => {
-      assert.equal('#/definitions/contact', xfmr.getDefinitionReference(sails, '/group/:parentid/contacts/:id'))
+      assert.equal('#/definitions/contact', xfmr.getDefinitionReferenceFromPath(sails, '/group/:parentid/contacts/:id'))
     })
     it('should generate a Swagger $ref from a pluralized association path /users', () => {
       sails.models['user'] = { identity: 'user' }
-      assert.equal('#/definitions/user', xfmr.getDefinitionReference(sails, '/users'))
+      assert.equal('#/definitions/user', xfmr.getDefinitionReferenceFromPath(sails, '/users'))
     })
     it('should generate a Swagger $ref from a pluralized association path /memories', () => {
       sails.models['memory'] = { identity: 'memory' }
-      assert.equal('#/definitions/memory', xfmr.getDefinitionReference(sails, '/memories'))
+      assert.equal('#/definitions/memory', xfmr.getDefinitionReferenceFromPath(sails, '/memories'))
     })
   })
 })

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -123,6 +123,12 @@ describe('xfmr', () => {
 
       assert(_.isObject(swaggerResponses))
     })
+    it('should generate a Swagger Responses object from a Sails route with body', () => {
+      let route = _.findWhere(sails.router._privateRouter.routes.post, {path: '/contact'})
+      let swaggerResponses = xfmr.getResponses(sails, route)
+
+      assert(_.isObject(swaggerResponses['200'].schema))
+    })
   })
 
   describe('#getDefinitionReference()', () => {

--- a/test/xfmr.test.js
+++ b/test/xfmr.test.js
@@ -65,6 +65,23 @@ describe('xfmr', () => {
       assert(_.isArray(params))
       assert.equal(params[0].name, 'id')
     })
+    it('should generate a Swagger Parameters object from a Sails model for POST endpoints', () => {
+      let route = _.findWhere(sails.router._privateRouter.routes.post, { path: '/contact' })
+      let params = xfmr.getParameters(sails, route)
+
+      assert(_.isArray(params))
+      assert.equal(params.length, 1)
+      assert.equal(params[0].name, 'contact');
+    })
+    it('should generate a Swagger Parameters object from a Sails model for PUT endpoints', () => {
+      let route = _.findWhere(sails.router._privateRouter.routes.post, { path: '/contact/:id' })
+      let params = xfmr.getParameters(sails, route)
+
+      assert(_.isArray(params))
+      assert.equal(params.length, 2)
+      assert.equal(params[0].name, 'id')
+      assert.equal(params[1].name, 'contact');
+    })
   })
   describe.skip('#getResponses', () => {
     it('should generate a Swagger Responses object from a Sails route', () => {


### PR DESCRIPTION
When models are singular (e.g. `User.js`) and routes are plural (e.g. `/users`) the definitions in the generated swagger document are not referenced in route responses.

This uses the pluralize library to derive the singular case when needed.

This adds body parameters to the swagger document for POST and PUT requests.
