### PR TITLE
add host option so it's compatible with postman

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module.exports.swagger = {
    */
   pkg: require('../package'),
   ui: {
+    host: 'localhost:1337',
     url: 'http://swagger.balderdash.io'
   }
 };


### PR DESCRIPTION
When importing to postman, there is no host to call the api.
