### PR TITLE
Changed swagger ui query param to 'doc' 

### DIFF
--- a/api/controllers/SwaggerController.js
+++ b/api/controllers/SwaggerController.js
@@ -5,7 +5,7 @@ const SwaggerController = {
 
   ui (req, res) {
     let docUrl = req.protocol + '://' + req.get('Host') + '/swagger/doc'
-    res.redirect(sails.config.swagger.ui.url + '?url=' + encodeURIComponent(docUrl))
+    res.redirect(sails.config.swagger.ui.url + '?doc=' + encodeURIComponent(docUrl))
   }
 }
 


### PR DESCRIPTION
Changed swagger ui query param to 'doc'  instead of 'url' which swagger ui uses
